### PR TITLE
Speed Up CI Builds

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -74,9 +74,9 @@ jobs:
           ~/Qt/5.13.1/gcc_64/bin/qmake \
             D-Viz.pro \
             CONFIG+=debug \
-            QMAKE_CXXFLAGS+=fno-inline \
-            QMAKE_CXXFLAGS+=fno-inline-small-functions \
-            QMAKE_CXXFLAGS+=fno-default-inline
+            QMAKE_CXXFLAGS+=-fno-inline \
+            QMAKE_CXXFLAGS+=-fno-inline-small-functions \
+            QMAKE_CXXFLAGS+=-fno-default-inline
           make -j4
 
       - name: Run Tests


### PR DESCRIPTION
+ Since the VMs apparently have 2-cores, we can speed up our builds by using 4 threads. This shaves about 140 seconds off the build. In other words, this reduces build times to 62% of what it was before the change.
+ Also added some additional flags to prevent inlining. This might help with coverage reporting.