### PR TITLE
Fix Qt Installation Issue on GitHub Actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,4 +1,4 @@
-name: Coverage
+name: Run Tests and Collect Coverage
 
 on: [push]
 


### PR DESCRIPTION
+ Given that Qt now requires an account to run the installer, we'll have to work around the fact that we can't interact with the installer. This problem is solved by writing account credentials to `~/.local/share/Qt/qtinstaller.ini`. The installer will read the credentials from this file and repopulate the  required fields. The sensitive credential data that's written to this `ini` file is stored as secret data in the GitHub repository.