### PR TITLE
Refactored Context Menu Creation and Added Error Messages

### DIFF
--- a/Include/View/Viewport/glCanvas.h
+++ b/Include/View/Viewport/glCanvas.h
@@ -354,9 +354,33 @@ class GLCanvas final : public QOpenGLWidget
     void VisualizeFilesystemActivity();
 
     /**
+     * @brief Helper function to add the OS options to the context menus.
+     *
+     * @param[in] menu              The menu that is to be populated.
+     * @param[in] fileType          The type of file currently selected; it is assumed one is
+     *                              selected.
+     * @param[in] selection         A pointer to the node that is currently selected; a valid
+     *                              selection is assumed.
+     */
+    template <typename MenuType>
+    void AddOperatingSystemOptionsToContextMenu(
+        MenuType& menu, FileType fileType, const Tree<VizBlock>::Node* const selection);
+
+    /**
      * @brief Helper function populate the context menus.
+     *
+     * @param[in] menu              The menu that is to be populated.
      */
     template <typename MenuType> void PopulateContextMenu(MenuType& menu);
+
+    /**
+     * @brief Displays an error message if the file is missing from disk.
+     *
+     * @param[in] path              The path to test.
+     *
+     * @returns True if the file is missing, and false if present.
+     */
+    bool AlertIfMissing(const std::filesystem::path& path);
 
     bool m_isPaintingSuspended{ false };
     bool m_isVisualizationLoaded{ false };

--- a/Include/controller.h
+++ b/Include/controller.h
@@ -212,7 +212,7 @@ class Controller : public QObject
      *
      * @returns The absolute file path.
      */
-    static std::filesystem::path ResolveCompleteFilePath(const Tree<VizBlock>::Node& node);
+    static std::filesystem::path NodeToFilePath(const Tree<VizBlock>::Node& node);
 
     /**
      * @brief Prints selection details to the main window's status bar.

--- a/Source/controller.cpp
+++ b/Source/controller.cpp
@@ -284,8 +284,7 @@ void Controller::SelectNodeAndUpdateStatusBar(
     const auto [prefixedSize, units] = Utilities::ToPrefixedSize(fileSize, prefix);
     const auto isSmallFile = (units == Utilities::Detail::bytesLabel);
 
-    const auto path = Controller::ResolveCompleteFilePath(node).wstring();
-
+    const auto path = Controller::NodeToFilePath(node).wstring();
     const auto message = isSmallFile ? fmt::format(L"{}  |  {:.0f} {}", path, prefixedSize, units)
                                      : fmt::format(L"{}  |  {:.2f} {}", path, prefixedSize, units);
 
@@ -470,7 +469,7 @@ void Controller::SearchTreeMap(
     ProcessHighlightedNodes(selector, selectionCallback);
 }
 
-std::filesystem::path Controller::ResolveCompleteFilePath(const Tree<VizBlock>::Node& node)
+std::filesystem::path Controller::NodeToFilePath(const Tree<VizBlock>::Node& node)
 {
     std::vector<std::reference_wrapper<const std::wstring>> reversePath;
     reversePath.reserve(Tree<VizBlock>::Depth(node));

--- a/Tests/modelTests.cpp
+++ b/Tests/modelTests.cpp
@@ -9,7 +9,7 @@
 
 namespace
 {
-    std::filesystem::path PathFromRootToNode(const Tree<VizBlock>::Node& node)
+    std::filesystem::path PathToNode(const Tree<VizBlock>::Node& node)
     {
         std::vector<std::reference_wrapper<const std::wstring>> reversePath;
         reversePath.reserve(Tree<VizBlock>::Depth(node));
@@ -52,7 +52,7 @@ namespace
                     return;
                 }
 
-                const auto path = PathFromRootToNode(node);
+                const auto path = PathToNode(node);
                 allEvents.emplace_back(
                     FileEvent{ path.wstring() + node->file.extension, eventType });
             });
@@ -310,12 +310,13 @@ void ModelTests::CopyPathToClipboard()
         Tree<VizBlock>::LeafIterator{ m_tree->GetRoot() }, Tree<VizBlock>::LeafIterator{},
         [&](const auto& node) { return (node->file.name + node->file.extension) == targetName; });
 
-    OS::CopyPathToClipboard(*targetNode);
+    const auto path = Controller::NodeToFilePath(*targetNode);
+    OS::CopyPathToClipboard(path);
 
     QClipboard* clipboard = QApplication::clipboard();
     const auto text = clipboard->text();
 
-    QCOMPARE(text.toStdString(), Controller::ResolveCompleteFilePath(*targetNode).string());
+    QCOMPARE(text.toStdString(), path.string());
 }
 
 void ModelTests::FindNearestNodeFromFront()


### PR DESCRIPTION
+ If the file can't be found, there will now be an error message.
+ Split context menu creation into two functions. It was getting a bit long.
+ The OS functions now take a path instead of a node.