### PR TITLE
Upgraded Boost to 1.76

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost/1.74.0
+boost/1.76.0
 
 [generators]
 qmake


### PR DESCRIPTION
+ Interestingly, it looks like Boost is only available as a pre-built binary with the C++14 standard flag set. Since we're only consuming header-only libraries at this point, this shouldn't be an issue.